### PR TITLE
setting the 2 dicts for each sentinel

### DIFF
--- a/sentle/sentinel1.py
+++ b/sentle/sentinel1.py
@@ -10,14 +10,25 @@ from .const import *
 from .reproject_util import *
 
 
-def process_ptile_S1(target_crs: CRS, target_resolution: float,
-                     time_composite_freq: str, bound_left, bound_right,
-                     bound_bottom, bound_top, ts, S1_assets, ptile_height,
-                     ptile_width, ptile_transform, item_list):
+def process_ptile_S1(**kwargs):
     """Processes a single sentinel 1 ptile. This includes downloading the
     data, reprojecting it to the target_crs and target_resolution. The function
     returns the reprojected ptile.
     """
+    target_crs: CRS = kwargs.get("target_crs")
+    target_resolution: float = kwargs.get("target_resolution")
+    time_composite_freq: str = kwargs.get("time_composite_freq")
+    bound_left = kwargs.get("bound_left")
+    bound_right = kwargs.get("bound_right")
+    bound_bottom = kwargs.get("bound_bottom")
+    bound_top = kwargs.get("bound_top")
+    ts = kwargs.get("ts")
+    S1_assets: list = kwargs.get("S1_assets")
+    ptile_height: int = kwargs.get("ptile_height")
+    ptile_width: int = kwargs.get("ptile_width")
+    ptile_transform: transform.Affine = kwargs.get("ptile_transform")
+    item_list: list = kwargs.get("item_list")
+
 
     # intiate one array representing the entire subtile for that timestamp
     ptile_array = np.full(shape=(len(S1_assets), ptile_height, ptile_width),

--- a/sentle/sentinel2.py
+++ b/sentle/sentinel2.py
@@ -246,29 +246,33 @@ def process_S2_subtile(
 
 
 def process_ptile_S2_dispatcher(
-    target_crs: CRS,
-    target_resolution: float,
-    S2_cloud_classification_device: str,
-    time_composite_freq: str,
-    S2_apply_snow_mask: bool,
-    S2_apply_cloud_mask: bool,
-    S2_bands_to_save,
-    ptile_height,
-    ptile_width,
-    ptile_transform,
-    item_list,
-    ts,
-    bound_left,
-    bound_right,
-    bound_bottom,
-    bound_top,
-    S2_mask_snow: bool,
-    S2_cloud_classification: bool,
-    S2_return_cloud_probabilities: bool,
-    S2_subtiles,
-    cloud_request_queue: mp.Queue,
-    cloud_response_queue: mp.Queue,
+    **kwargs
 ):
+    
+    target_crs: CRS = kwargs.get("target_crs")
+    target_resolution: float = kwargs.get("target_resolution")
+    S2_mask_snow: bool = kwargs.get("S2_mask_snow", False)
+    S2_cloud_classification: bool = kwargs.get("S2_cloud_classification",
+                                               False)
+    S2_cloud_classification_device: str = kwargs.get(
+        "S2_cloud_classification_device", "cpu")
+    S2_return_cloud_probabilities: bool = kwargs.get(
+        "S2_return_cloud_probabilities", False)
+    S2_subtiles = kwargs.get("S2_subtiles")
+    S2_bands_to_save = kwargs.get("S2_bands_to_save", S2_RAW_BANDS)
+    S2_snow_mask_band = kwargs.get("S2_snow_mask_band", S2_snow_mask_band)
+    S2_cloud_mask_band = kwargs.get("S2_cloud_mask_band", S2_cloud_mask_band)
+    time_composite_freq = kwargs.get("time_composite_freq", None)
+    item_list = kwargs.get("item_list")
+    stac_item = kwargs.get("stac_item")
+    intersecting_windows = kwargs.get("intersecting_windows")
+    ptile_transform = kwargs.get("ptile_transform")
+    ptile_width: int = kwargs.get("ptile_width")
+    ptile_height: int = kwargs.get("ptile_height")
+    cloud_request_queue: mp.Queue = kwargs.get("cloud_request_queue")
+    timestamp = kwargs.get("timestamp")
+
+
 
     items = pd.DataFrame()
     items["item"] = item_list

--- a/sentle/sentle.py
+++ b/sentle/sentle.py
@@ -89,6 +89,7 @@ def process_ptile(
     job_id: int,
     sync_file_path: str,
 ):
+
     """Passing chunk to either sentinel-1 or sentinel-2 processor"""
 
     # determine ptile dimensions and transform from bounds
@@ -116,46 +117,52 @@ def process_ptile(
     if len(item_list) == 0:
         # no items found for this ptile, this happens sometimes. planetary problem. dunno why.
         return job_id
+    
+    s1_args = {
+    "bound_left": bound_left,
+    "bound_right": bound_right,
+    "bound_bottom": bound_bottom,
+    "bound_top": bound_top,
+    "target_crs": target_crs,
+    "target_resolution": target_resolution,
+    "time_composite_freq": time_composite_freq,
+    "ts": ts,
+    "S1_assets": S1_assets,
+    "ptile_height": ptile_height,
+    "ptile_width": ptile_width,
+    "ptile_transform": ptile_transform,
+    "item_list": item_list,
+    }
+
+    s2_args = {
+        "bound_left": bound_left,
+        "bound_right": bound_right,
+        "bound_bottom": bound_bottom,
+        "bound_top": bound_top,
+        "target_crs": target_crs,
+        "target_resolution": target_resolution,
+        "time_composite_freq": time_composite_freq,
+        "ts": ts,
+        "S2_assets": S2_bands_to_save,
+        "S2_cloud_classification_device": S2_cloud_classification_device,
+        "S2_apply_snow_mask": S2_apply_snow_mask,
+        "S2_apply_cloud_mask": S2_apply_cloud_mask,
+        "S2_mask_snow": S2_mask_snow,
+        "S2_cloud_classification": S2_cloud_classification,
+        "S2_return_cloud_probabilities": S2_return_cloud_probabilities,
+        "ptile_height": ptile_height,
+        "ptile_width": ptile_width,
+        "ptile_transform": ptile_transform,
+        "item_list": item_list,
+        "S2_subtiles": S2_subtiles,
+        "cloud_request_queue": cloud_request_queue,
+        "cloud_response_queue": cloud_response_queue,
+    }
 
     if collection == "sentinel-1-rtc":
-        ptile_array = process_ptile_S1(bound_left=bound_left,
-                                       bound_bottom=bound_bottom,
-                                       bound_right=bound_right,
-                                       bound_top=bound_top,
-                                       target_crs=target_crs,
-                                       ts=ts,
-                                       ptile_height=ptile_height,
-                                       ptile_width=ptile_width,
-                                       ptile_transform=ptile_transform,
-                                       item_list=item_list,
-                                       target_resolution=target_resolution,
-                                       time_composite_freq=time_composite_freq,
-                                       S1_assets=S1_assets)
+        ptile_array = process_ptile_S1(**s1_args)
     elif collection == "sentinel-2-l2a":
-        ptile_array = process_ptile_S2_dispatcher(
-            bound_left=bound_left,
-            bound_bottom=bound_bottom,
-            bound_right=bound_right,
-            bound_top=bound_top,
-            ts=ts,
-            target_crs=target_crs,
-            ptile_height=ptile_height,
-            ptile_width=ptile_width,
-            ptile_transform=ptile_transform,
-            item_list=item_list,
-            target_resolution=target_resolution,
-            S2_cloud_classification=S2_cloud_classification,
-            S2_cloud_classification_device=S2_cloud_classification_device,
-            S2_mask_snow=S2_mask_snow,
-            S2_return_cloud_probabilities=S2_return_cloud_probabilities,
-            time_composite_freq=time_composite_freq,
-            S2_apply_snow_mask=S2_apply_snow_mask,
-            S2_apply_cloud_mask=S2_apply_cloud_mask,
-            S2_bands_to_save=S2_bands_to_save,
-            S2_subtiles=S2_subtiles,
-            cloud_request_queue=cloud_request_queue,
-            cloud_response_queue=cloud_response_queue,
-        )
+        ptile_array = process_ptile_S2_dispatcher(**s2_args)
 
     else:
         assert False


### PR DESCRIPTION
I refactored the code to use two dictionaries to pass the necessary arguments to the Sentinel-1 and Sentinel-2 processing functions.

This makes the function signatures cleaner and easier to maintain.
If new attributes need to be added to the processing logic, simply include them in the corresponding dictionary and handle them inside the Sentinel-specific processing function.

this pull request  for the issue https://github.com/cmosig/sentle/issues/46